### PR TITLE
Validação específica para o CPF

### DIFF
--- a/app/Http/Requests/StoreUserRequest.php
+++ b/app/Http/Requests/StoreUserRequest.php
@@ -27,7 +27,7 @@ class StoreUserRequest extends FormRequest
             'name' => 'required|string|max:255',
             'email' => 'required|email|unique:users,email',
             'password' => 'required|string|min:6',
-            'cpf' => 'required|string|min:11|max:11|unique:users,cpf',
+            'cpf' => 'required|string|cpf|unique:users,cpf',
             'cep' => 'required|string|min:8|max:8',
             'birth_date' => 'required|date_format:d/m/Y',
         ];

--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -29,7 +29,7 @@ class UpdateUserRequest extends FormRequest
             'name' => 'required|string|max:255',
             'email' => 'required|email|unique:users,email,' . $userId,
             'password' => 'sometimes|nullable|string|min:6',
-            'cpf' => 'required|string|min:11|max:11|unique:users,cpf,' . $userId,
+            'cpf' => 'required|string|cpf|unique:users,cpf,' . $userId,
             'cep' => 'required|string|min:8|max:8',
             'birth_date' => 'required|date_format:d/m/Y',
         ];

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.10",
         "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1"
+        "laravel/tinker": "^2.10.1",
+        "laravellegends/pt-br-validator": "^12.2"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "46da273005044d34b20940dbf4e21a8b",
+    "content-hash": "5cd0e84202f1ae7fd80f9a48b59342d5",
     "packages": [
         {
             "name": "brick/math",
@@ -1455,6 +1455,57 @@
                 "source": "https://github.com/laravel/tinker/tree/v2.10.1"
             },
             "time": "2025-01-27T14:24:01+00:00"
+        },
+        {
+            "name": "laravellegends/pt-br-validator",
+            "version": "12.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/LaravelLegends/pt-br-validator.git",
+                "reference": "9c04c518a99047edb1da4cbf82dabb124da6bc94"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/LaravelLegends/pt-br-validator/zipball/9c04c518a99047edb1da4cbf82dabb124da6bc94",
+                "reference": "9c04c518a99047edb1da4cbf82dabb124da6bc94",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^10.0",
+                "phpunit/phpunit": "^8.3 || ^9.0 || ^11.5.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "LaravelLegends\\PtBrValidator\\ValidatorProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LaravelLegends\\PtBrValidator\\": "src/pt-br-validator"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Wallace de Souza Vizerra",
+                    "email": "wallacemaxters@gmail.com"
+                }
+            ],
+            "description": "Uma biblioteca contendo validações de formatos Brasileiros, para o Laravel",
+            "support": {
+                "issues": "https://github.com/LaravelLegends/pt-br-validator/issues",
+                "source": "https://github.com/LaravelLegends/pt-br-validator/tree/12.2.0"
+            },
+            "time": "2025-06-21T21:37:01+00:00"
         },
         {
             "name": "league/commonmark",


### PR DESCRIPTION
Instalação da biblioteca pt-br-validator (https://github.com/LaravelLegends/pt-br-validator) e aplicação da validação específica para CPFs.